### PR TITLE
Add managed storage support

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -186,7 +186,8 @@ const getStoredOptions = () => {
                 resolve(options);
             });
         }),
-        new Promise((resolve) => {
+        // chrome.storage.managed is supported on Firefox 57 and later
+        !chrome.storage.managed ? null : new Promise((resolve) => {
             chrome.storage.managed.get(null, managedOptions => {
                 if (chrome.runtime.lastError) console.error("getStoredOptions error on getting managed storage:", chrome.runtime.lastError.message);
                 resolve(managedOptions);

--- a/helper.js
+++ b/helper.js
@@ -194,8 +194,8 @@ const getStoredOptions = () => {
             });
         })
     ]).then(results => {
-      const [options, managedOptions] = results;
-      return Object.assign({}, options || {}, managedOptions || {});
+        const [options, managedOptions] = results;
+        return Object.assign({}, options || {}, managedOptions || {});
     });
 };
 

--- a/helper.js
+++ b/helper.js
@@ -180,18 +180,18 @@ const setWindowBadgeBackgroundColor = (windowId, color) => {
 /* exported getStoredOptions */
 const getStoredOptions = () => {
     return Promise.all([
-    new Promise((resolve) => {
-        chrome.storage.local.get(null, options => {
-            if (chrome.runtime.lastError) console.error("getStoredOptions error on getting local storage:", chrome.runtime.lastError.message);
-            resolve(options);
-        });
-    }),
-    new Promise((resolve) => {
-        chrome.storage.managed.get(null, managedOptions => {
-            if (chrome.runtime.lastError) console.error("getStoredOptions error on getting managed storage:", chrome.runtime.lastError.message);
-            resolve(managedOptions);
-        });
-    })
+        new Promise((resolve) => {
+            chrome.storage.local.get(null, options => {
+                if (chrome.runtime.lastError) console.error("getStoredOptions error on getting local storage:", chrome.runtime.lastError.message);
+                resolve(options);
+            });
+        }),
+        new Promise((resolve) => {
+            chrome.storage.managed.get(null, managedOptions => {
+                if (chrome.runtime.lastError) console.error("getStoredOptions error on getting managed storage:", chrome.runtime.lastError.message);
+                resolve(managedOptions);
+            });
+        })
     ]).then(results => {
       const [options, managedOptions] = results;
       return Object.assign({}, options || {}, managedOptions || {});

--- a/helper.js
+++ b/helper.js
@@ -179,11 +179,22 @@ const setWindowBadgeBackgroundColor = (windowId, color) => {
 
 /* exported getStoredOptions */
 const getStoredOptions = () => {
-    return new Promise((resolve) => {
+    return Promise.all([
+    new Promise((resolve) => {
         chrome.storage.local.get(null, options => {
-            if (chrome.runtime.lastError) console.error("getStoredOptions error:", chrome.runtime.lastError.message);
+            if (chrome.runtime.lastError) console.error("getStoredOptions error on getting local storage:", chrome.runtime.lastError.message);
             resolve(options);
         });
+    }),
+    new Promise((resolve) => {
+        chrome.storage.managed.get(null, managedOptions => {
+            if (chrome.runtime.lastError) console.error("getStoredOptions error on getting managed storage:", chrome.runtime.lastError.message);
+            resolve(managedOptions);
+        });
+    })
+    ]).then(results => {
+      const [options, managedOptions] = results;
+      return Object.assign({}, options || {}, managedOptions || {});
     });
 };
 

--- a/messageListener.js
+++ b/messageListener.js
@@ -10,7 +10,18 @@ const handleMessage = (message, sender, response) => {
             break;
         }
         case "getOptions": {
-            chrome.storage.local.get(null, storedOptions => sendResponse(storedOptions));
+            Promise.all([
+                new Promise((resolve) => {
+                    chrome.storage.local.get(null, storedOptions => resolve(storedOptions));
+                }),
+                // chrome.storage.managed is supported on Firefox 57 and later
+                !chrome.storage.managed ? null : new Promise((resolve) => {
+                    chrome.storage.managed.get(null, managedOptions => {resolve(managedOptions));
+                })
+            ]).then(results => {
+              const [storedOptions, managedOptions] = results;
+              sendResponse(Object.assign({}, storedOptions || {}, managedOptions || {}));
+            });
             return true;
         }
         case "getDuplicateTabs": {

--- a/messageListener.js
+++ b/messageListener.js
@@ -19,8 +19,11 @@ const handleMessage = (message, sender, response) => {
                     chrome.storage.managed.get(null, managedOptions => resolve(managedOptions));
                 })
             ]).then(results => {
-              const [storedOptions, managedOptions] = results;
-              sendResponse(Object.assign({}, storedOptions || {}, managedOptions || {}));
+                const [storedOptions, managedOptions] = results;
+                sendResponse({
+                    options:    Object.assign({}, storedOptions || {}, managedOptions || {}),
+                    lockedKeys: Object.keys(managedOptions || {})
+                });
             });
             return true;
         }

--- a/messageListener.js
+++ b/messageListener.js
@@ -16,7 +16,7 @@ const handleMessage = (message, sender, response) => {
                 }),
                 // chrome.storage.managed is supported on Firefox 57 and later
                 !chrome.storage.managed ? null : new Promise((resolve) => {
-                    chrome.storage.managed.get(null, managedOptions => {resolve(managedOptions));
+                    chrome.storage.managed.get(null, managedOptions => resolve(managedOptions));
                 })
             ]).then(results => {
               const [storedOptions, managedOptions] = results;

--- a/optionPage/optionPage.css
+++ b/optionPage/optionPage.css
@@ -235,3 +235,7 @@ fieldset[disabled] .btn-close-tabs.active {
   color: #FFFFFF;
   border: 1px solid #18A9EB;
 }
+
+label > input:disabled ~ * {
+  opacity: 0.5;
+}

--- a/optionPage/optionPage.js
+++ b/optionPage/optionPage.js
@@ -139,11 +139,12 @@ const saveOption = (name, value, refresh) => sendMessage("setStoredOption", {
   "refresh": refresh
 });
 
-const setPanelOption = (option, value) => {
+const setPanelOption = (option, value, locked = false) => {
   if (option === "environment") {
     if (value === "chrome") $("#containerItem").toggleClass("hidden", true);
   } else if (option === "whiteList") {
     $("#whiteList").val(value);
+    if (locked) $("#whiteList").prop("disabled", true);
   } else {
     if (typeof (value) === "boolean") {
       $("#" + option).prop("checked", value);
@@ -153,14 +154,16 @@ const setPanelOption = (option, value) => {
       $("#" + option + " option[value='" + value + "']").prop("selected", true);
       if (option === "onDuplicateTabDetected") changeAutoCloseOptionState(value);
     }
+    if (locked) $("#" + option).prop("disabled", true);
   }
 };
 
 const setPanelOptions = async () => {
   const response = await sendMessage("getOptions");
-  const options = response.data;
+  const options = response.data.options;
+  const lockedKeys = new Set(response.data.lockedKeys);
   for (const option in options) {
-    setPanelOption(option, options[option].value);
+    setPanelOption(option, options[option].value, lockedKeys.has(option));
   }
 };
 

--- a/optionPage/optionPage.js
+++ b/optionPage/optionPage.js
@@ -161,9 +161,9 @@ const setPanelOption = (option, value, locked = false) => {
 const setPanelOptions = async () => {
   const response = await sendMessage("getOptions");
   const options = response.data.options;
-  const lockedKeys = new Set(response.data.lockedKeys);
+  const lockedKeys = response.data.lockedKeys;
   for (const option in options) {
-    setPanelOption(option, options[option].value, lockedKeys.has(option));
+    setPanelOption(option, options[option].value, lockedKeys.includes(option));
   }
 };
 

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -246,3 +246,7 @@ fieldset[disabled] .btn-close-tabs.active {
   color: #FFFFFF;
   border: 1px solid #18A9EB;
 }
+
+label > input:disabled ~ * {
+  opacity: 0.5;
+}

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -187,7 +187,8 @@ const requestGetDuplicateTabs = async () => {
 
 const setPanelOptions = async () => {
   const response = await sendMessage("getOptions");
-  const options = response.data;
+  const options = response.data.options;
+  const lockedKeys = new Set(response.data.lockedKeys);
   let isPinnedOptions = false;
 
   for (const option in options) {
@@ -204,6 +205,7 @@ const setPanelOptions = async () => {
         $("#" + option + " option[value='" + value + "']").prop("selected", true);
         if (option === "onDuplicateTabDetected") changeAutoCloseOptionState(value, false);
       }
+      if (lockedKeys.has(option)) $("#" + option).prop("disabled", true);
     }
   }
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -188,7 +188,7 @@ const requestGetDuplicateTabs = async () => {
 const setPanelOptions = async () => {
   const response = await sendMessage("getOptions");
   const options = response.data.options;
-  const lockedKeys = new Set(response.data.lockedKeys);
+  const lockedKeys = response.data.lockedKeys;
   let isPinnedOptions = false;
 
   for (const option in options) {
@@ -205,7 +205,7 @@ const setPanelOptions = async () => {
         $("#" + option + " option[value='" + value + "']").prop("selected", true);
         if (option === "onDuplicateTabDetected") changeAutoCloseOptionState(value, false);
       }
-      if (lockedKeys.has(option)) $("#" + option).prop("disabled", true);
+      if (lockedKeys.includes(option)) $("#" + option).prop("disabled", true);
     }
   }
 


### PR DESCRIPTION
I'm planning to deploy this add-on to multiple clients in a company with some modified default options. I hope to use the [managed storage system](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed) instead of modifying of default option definitions. This change will help other people who have same demand. Could you merge this change?