### PR TITLE
Change compareWithTitle logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -13,6 +13,7 @@ const onBeforeNavigate = async (details) => {
 		const tab = await getTab(details.tabId);
 		if (tab) {
 			tabsInfo.resetTab(tab.id);
+			if (tab.status === "loading" || isBlank(tab.url)) return;
 			searchForDuplicateTabsToClose(tab, true, details.url);
 		}
 	}

--- a/worker.js
+++ b/worker.js
@@ -6,11 +6,13 @@ const isUrlWhiteListed = (url) => {
 };
 
 const matchTitle = (tab1, tab2) => {
-    if (options.compareWithTitle) {
-        if ((isTabComplete(tab1) && isTabComplete(tab2)) && (tab1.title === tab2.title)) {
-            return true;
-        }
+    if (!options.compareWithTitle)
+        return true;
+
+    if ((isTabComplete(tab1) && isTabComplete(tab2)) && (tab1.title === tab2.title)) {
+        return true;
     }
+
     return false;
 };
 
@@ -120,7 +122,7 @@ const searchForDuplicateTabsToClose = async (observedTab, queryComplete, loading
         let match = false;
         for (const openedTab of openedTabs) {
             if ((openedTab.id === observedTab.id) || tabsInfo.isIgnoredTab(openedTab.id) || (isBlankURL(openedTab.url) && !isTabComplete(openedTab))) continue;
-            if ((getMatchingURL(openedTab.url) === matchingObservedTabUrl) || matchTitle(openedTab, observedTab)) {
+            if ((getMatchingURL(openedTab.url) === matchingObservedTabUrl) && matchTitle(openedTab, observedTab)) {
                 match = true;
                 const [tabToCloseId, remainingTabInfo] = getCloseInfo({ observedTab: observedTab, observedTabUrl: observedTabUrl, openedTab: openedTab });
                 closeDuplicateTab(tabToCloseId, remainingTabInfo);


### PR DESCRIPTION
This addresses #52.
Unfortunately, it does not solve the problem with the outlook.office.com
webapp and other sites that change their title after onComplete has fired.

---
Change the behaviour of the compareWithTitle option such that it is
treated the same as any of the ignore* options, namely as an additional
matching rule that contrains the results of the duplicate search even
further.

More precisely, now if option.compareWithTitle===true, then tabs with
the same URL (subject to the other matching rules) only match iff they
also share the same title.
Previously, matching in URLs alone would have sufficed.
