### PR TITLE
untracked tabs shouldn't be treated as ignored

### DIFF
--- a/tabsInfo.js
+++ b/tabsInfo.js
@@ -33,7 +33,8 @@ class TabsInfo {
 
     isIgnoredTab(tabId) {
         const tab = this.tabs.get(tabId);
-        return (!tab || tab.ignored) ? true : false;
+        if (!tab) return false;
+        return tab.ignored;
     }
 
     getLastComplete(tabId) {


### PR DESCRIPTION
I was debugging why the extension wasn't detecting several duplicate cases.

I isolated it to this.  

TBH I don't fully understand what this ignored state is meant to capture, but.... it does seem reasonable to not exclude items from evaluation even if the bookkeeping isn't up to date.

