### PR TITLE
Update to Manifest v3 (per Bug #86)

### DIFF
--- a/badge.js
+++ b/badge.js
@@ -2,8 +2,8 @@
 
 // eslint-disable-next-line no-unused-vars
 const setBadgeIcon = () => {
-	chrome.browserAction.setIcon({ path: options.autoCloseTab ? "images/auto_close_16.png" : "images/manual_close_16.png" });
-	if (environment.isFirefox) browser.browserAction.setBadgeTextColor({ color: "white" });
+	chrome.action.setIcon({ path: options.autoCloseTab ? "images/auto_close_16.png" : "images/manual_close_16.png" });
+	if (environment.isFirefox) browser.action.setBadgeTextColor({ color: "white" });
 };
 
 const setBadge = async (windowId, activeTabId) => {

--- a/build/list.txt
+++ b/build/list.txt
@@ -6,6 +6,7 @@ manifest.json
 messageListener.js
 options.js
 README.md
+scriptImport.js
 tabsInfo.js
 urlUtils.js
 worker.js

--- a/helper.js
+++ b/helper.js
@@ -143,7 +143,7 @@ const removeTab = (tabId) => new Promise((resolve, reject) => {
 
 // eslint-disable-next-line no-unused-vars
 const setIcon = (details) => new Promise((resolve) => {
-    chrome.browserAction.setIcon(details, () => {
+    chrome.action.setIcon(details, () => {
         if (chrome.runtime.lastError) console.error("setIcon error:", chrome.runtime.lastError.message);
         resolve();
     });
@@ -151,14 +151,14 @@ const setIcon = (details) => new Promise((resolve) => {
 
 // eslint-disable-next-line no-unused-vars
 const getTabBadgeText = (tabId) => new Promise((resolve) => {
-    chrome.browserAction.getBadgeText({ tabId: tabId }, badgeText => {
+    chrome.action.getBadgeText({ tabId: tabId }, badgeText => {
         if (chrome.runtime.lastError) console.error("getTabBadgeText error:", chrome.runtime.lastError.message);
         resolve(badgeText);
     });
 });
 
 // eslint-disable-next-line no-unused-vars
-const getWindowBadgeText = (windowId) => browser.browserAction.getBadgeText({ windowId: windowId });
+const getWindowBadgeText = (windowId) => browser.action.getBadgeText({ windowId: windowId });
 
 // eslint-disable-next-line no-unused-vars
 const setTabBadgeText = (tabId, text) => new Promise((resolve) => {
@@ -167,25 +167,25 @@ const setTabBadgeText = (tabId, text) => new Promise((resolve) => {
         resolve();
         return;
     }    
-    chrome.browserAction.setBadgeText({ tabId: tabId, text: text }, () => {
+    chrome.action.setBadgeText({ tabId: tabId, text: text }, () => {
         if (chrome.runtime.lastError) console.error("setTabBadgeText error:", chrome.runtime.lastError.message);
         resolve();
     });
 });
 
 // eslint-disable-next-line no-unused-vars
-const setWindowBadgeText = (windowId, text) => browser.browserAction.setBadgeText({ windowId: windowId, text: text });
+const setWindowBadgeText = (windowId, text) => browser.action.setBadgeText({ windowId: windowId, text: text });
 
 // eslint-disable-next-line no-unused-vars
 const setTabBadgeBackgroundColor = (tabId, color) => new Promise((resolve) => {
-    chrome.browserAction.setBadgeBackgroundColor({ tabId: tabId, color: color }, () => {
+    chrome.action.setBadgeBackgroundColor({ tabId: tabId, color: color }, () => {
         if (chrome.runtime.lastError) console.error("setTabBadgeBackgroundColor error:", chrome.runtime.lastError.message);
         resolve();
     });
 });
 
 // eslint-disable-next-line no-unused-vars
-const setWindowBadgeBackgroundColor = (windowId, color) => browser.browserAction.setBadgeBackgroundColor({ windowId: windowId, color: color });
+const setWindowBadgeBackgroundColor = (windowId, color) => browser.action.setBadgeBackgroundColor({ windowId: windowId, color: color });
 
 // eslint-disable-next-line no-unused-vars
 const getStoredOptions = () => Promise.all([

--- a/manifest-c.json
+++ b/manifest-c.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Duplicate Tabs Closer",
   "version": "3.5.3",
   "author": "Peuj",
@@ -9,19 +9,9 @@
     "48": "images/auto_close_32.png"
   },
   "background": {
-    "scripts": [
-      "helper.js",
-      "tabsInfo.js",
-      "options.js",
-      "urlUtils.js",
-      "badge.js",
-      "worker.js",
-      "messageListener.js",
-      "background.js"
-    ]
+    "service_worker": "scriptImport.js"
   },
-  "browser_action": {
-    "browser_style": false,
+  "action": {
     "default_icon": {
       "16": "images/auto_close_16.png",
       "32": "images/auto_close_32.png"

--- a/manifest-f.json
+++ b/manifest-f.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Duplicate Tabs Closer",
   "version": "3.5.3",
   "author": "Peuj",

--- a/manifest-f.json
+++ b/manifest-f.json
@@ -11,7 +11,7 @@
   "applications": {
     "gecko": {
       "id": "jid0-RvYT2rGWfM8q5yWxIxAHYAeo5Qg@jetpack",
-      "strict_min_version": "68.0"
+      "strict_min_version": "101.0"
     }
   },
   "background": {

--- a/options.js
+++ b/options.js
@@ -183,11 +183,12 @@ const setEnvironment = (storedOptions) => {
 };
 
 // eslint-disable-next-line no-unused-vars
-const isPanelOptionOpen = () => {
-    const popups = chrome.extension.getViews({ type: "popup" });
+const isPanelOptionOpen = () => { 
+    return false; //override for now, until replacement API comes in
+    /* const popups = chrome.extension.getViews({ type: "popup" });
     if (popups.length) return true;
     const tabs = chrome.extension.getViews({ type: "tab" });
-    return tabs.length > 0;
+    return tabs.length > 0; */
 };
 
 const whiteListToPattern = (whiteList) => {

--- a/scriptImport.js
+++ b/scriptImport.js
@@ -1,0 +1,5 @@
+try {
+  importScripts("helper.js", "tabsInfo.js", "options.js", "urlUtils.js", "badge.js", "worker.js", "messageListener.js", "background.js");
+} catch (e) {
+  console.error(e);
+}


### PR DESCRIPTION
I followed the guide at https://developer.chrome.com/docs/extensions/develop/migrate

There was one API that doesn't exist in Mv3, but the difference in functionality seems minimal. (Script can no longer detect if a popup is open.)