### PR TITLE
Feature/consistent ignore query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ To install this add-on from source in Firefox, follow these steps:
 1.  **Download the Source Code:**
     *   Clone the repository or download the source code ZIP file from the repository page and extract it to a local directory.
 
+2.  **Copy appropriate manifest:**
+    *   Copy either manifest to manifest.json using the cp command.
+    *   For **Firefox**:
+        ```sh
+        cp manifest-f.json manifest.json
+        ```
+    *   For **Chrome**:
+        ```sh
+        cp manifest-c.json manifest.json
+        ```
+
 2.  **Open Firefox and Navigate to `about:debugging`:**
     *   Type `about:debugging` into the Firefox address bar and press Enter.
 
@@ -80,7 +91,7 @@ To install this add-on from source in Firefox, follow these steps:
 4.  **Load Temporary Add-on:**
     *   Click the "Load Temporary Add-on…" button.
     *   Navigate to the directory where you extracted the add-on's source code.
-    *   Select the `manifest-f.json` file (or any file within the root directory of the extension, Firefox will find the manifest).
+    *   Select the `manifest.json` file.
     *   Click "Open".
 
 5.  **The add-on is now installed temporarily.** It will remain installed until you remove it or restart Firefox. If you make changes to the add-on's code, you'll need to click the "Reload" button for the add-on in `about:debugging` to apply the changes.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Wildcards and RegExp are supported.
 * **Ignore search part in URL** *(default off)*
 * **Ignore path part in URL** *(default off)*
 * **Compare with tab title** *(default off)*
+* * **Added 6/30/2025**
+* **Ignore utm_source query paramter** *(default on)*
+* **Ignore utm_campaign query paramter** *(default on)*
+* **Ignore utm_medium query paramter** *(default on)*
+* **Ignore _bhlid query paramter** *(default on)*
 
 
 ### Scope:
@@ -63,35 +68,3 @@ Wildcards and RegExp are supported.
 ### Hotkey:
 
 * **Alt+Shift+W** to close all duplicate tabs (this could be configured in the options in future version)
-
-## Installing from Source in Firefox
-
-To install this add-on from source in Firefox, follow these steps:
-
-1.  **Download the Source Code:**
-    *   Clone the repository or download the source code ZIP file from the repository page and extract it to a local directory.
-
-2.  **Copy appropriate manifest:**
-    *   Copy either manifest to manifest.json using the cp command.
-    *   For **Firefox**:
-        ```sh
-        cp manifest-f.json manifest.json
-        ```
-    *   For **Chrome**:
-        ```sh
-        cp manifest-c.json manifest.json
-        ```
-
-2.  **Open Firefox and Navigate to `about:debugging`:**
-    *   Type `about:debugging` into the Firefox address bar and press Enter.
-
-3.  **Enable Add-on Debugging:**
-    *   Click on "This Firefox" (or "This Nightly", "This Developer Edition" depending on your Firefox version).
-
-4.  **Load Temporary Add-on:**
-    *   Click the "Load Temporary Add-on…" button.
-    *   Navigate to the directory where you extracted the add-on's source code.
-    *   Select the `manifest.json` file.
-    *   Click "Open".
-
-5.  **The add-on is now installed temporarily.** It will remain installed until you remove it or restart Firefox. If you make changes to the add-on's code, you'll need to click the "Reload" button for the add-on in `about:debugging` to apply the changes.

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ Duplicate Tabs Closer detects and closes duplicate tabs.
 * **Do nothing**: monitor tabs and update the badge icon to indicate the number of duplicate tabs detected.
 
 #### On remaining tab:
-(Used with option *Close tab automatically*)  
+(Used with option *Close tab automatically*)
 * **Do nothing** *(default)*: nothing is done after the duplicate tab is closed.
 * **Activate**: once the duplicate tab is closed, the remaining tab is activated.
 * **Apply opening tab behavior**: once the duplicate tab is closed, depending on the default tab behavior, the remaining tab will be moved to the position of the closed tab and activated if needed.
 
 #### Whiltelist":
-(Used with option *Close tab automatically*)  
-List of urls to not close automatically. Duplicate tabs skipped will be notified in badge.  
+(Used with option *Close tab automatically*)
+List of urls to not close automatically. Duplicate tabs skipped will be notified in badge.
 Wildcards and RegExp are supported.
 
 
 ### Priority:
-(Used with option *Close tab automatically* and *Close all duplicate tabs* button)  
+(Used with option *Close tab automatically* and *Close all duplicate tabs* button)
 * **Keep older tab** *(default)*: Keep the already existing tab.
 * **Keep newer tab**: Keep the newer tab.
 * **Keep tab with https** *(default on)*: Ignore the scheme part during comparison and keep the tab with the https scheme.
@@ -63,3 +63,24 @@ Wildcards and RegExp are supported.
 ### Hotkey:
 
 * **Alt+Shift+W** to close all duplicate tabs (this could be configured in the options in future version)
+
+## Installing from Source in Firefox
+
+To install this add-on from source in Firefox, follow these steps:
+
+1.  **Download the Source Code:**
+    *   Clone the repository or download the source code ZIP file from the repository page and extract it to a local directory.
+
+2.  **Open Firefox and Navigate to `about:debugging`:**
+    *   Type `about:debugging` into the Firefox address bar and press Enter.
+
+3.  **Enable Add-on Debugging:**
+    *   Click on "This Firefox" (or "This Nightly", "This Developer Edition" depending on your Firefox version).
+
+4.  **Load Temporary Add-on:**
+    *   Click the "Load Temporary Add-on…" button.
+    *   Navigate to the directory where you extracted the add-on's source code.
+    *   Select the `manifest-f.json` file (or any file within the root directory of the extension, Firefox will find the manifest).
+    *   Click "Open".
+
+5.  **The add-on is now installed temporarily.** It will remain installed until you remove it or restart Firefox. If you make changes to the add-on's code, you'll need to click the "Reload" button for the add-on in `about:debugging` to apply the changes.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -158,5 +158,21 @@
   "shrunkMode": {
     "message":  "Shrunk mode:\nWhen activated, hide unpinned options.",
     "description":  "Shrunk mode\nWhen activated, hide unpinned options."
-  }  
+  },
+  "ignore_utm_source_label": {
+    "message": "Ignore utm_source parameter",
+    "description": "Label for ignoring utm_source parameter"
+  },
+  "ignore_utm_campaign_label": {
+    "message": "Ignore utm_campaign parameter",
+    "description": "Label for ignoring utm_campaign parameter"
+  },
+  "ignore_utm_medium_label": {
+    "message": "Ignore utm_medium parameter",
+    "description": "Label for ignoring utm_medium parameter"
+  },
+  "ignore_bhlid_label": {
+    "message": "Ignore _bhlid parameter",
+    "description": "Label for ignoring _bhlid parameter"
+  }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -174,5 +174,9 @@
   "ignore_bhlid_label": {
     "message": "Ignore _bhlid parameter",
     "description": "Label for ignoring _bhlid parameter"
+  },
+  "ignore_asuniq_label": {
+    "message": "Ignore asuniq parameter",
+    "description": "Label for ignoring asuniq parameter"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -158,5 +158,21 @@
   "shrunkMode": {
     "message":  "Shrunk mode:\nQuand il est activé, cache les options qui ne sont pas épinglées.",
     "description":  "Shrunk mode\nQuand il est activé, cache les options qui ne sont pas épinglées."
-  }  
+  },
+  "ignore_utm_source_label": {
+    "message": "Ignore utm_source parameter",
+    "description": "Label for ignoring utm_source parameter"
+  },
+  "ignore_utm_campaign_label": {
+    "message": "Ignore utm_campaign parameter",
+    "description": "Label for ignoring utm_campaign parameter"
+  },
+  "ignore_utm_medium_label": {
+    "message": "Ignore utm_medium parameter",
+    "description": "Label for ignoring utm_medium parameter"
+  },
+  "ignore_bhlid_label": {
+    "message": "Ignore _bhlid parameter",
+    "description": "Label for ignoring _bhlid parameter"
+  }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -174,5 +174,9 @@
   "ignore_bhlid_label": {
     "message": "Ignore _bhlid parameter",
     "description": "Label for ignoring _bhlid parameter"
+  },
+  "ignore_asuniq_label": {
+    "message": "Ignore asuniq parameter",
+    "description": "Label for ignoring asuniq parameter"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -158,5 +158,21 @@
   "shrunkMode": {
     "message":  "Shrunk mode:\nWhen activated, hide unpinned options.",
     "description":  "Shrunk mode\nWhen activated, hide unpinned options."
-  }  
+  },
+  "ignore_utm_source_label": {
+    "message": "Ignore utm_source parameter",
+    "description": "Label for ignoring utm_source parameter"
+  },
+  "ignore_utm_campaign_label": {
+    "message": "Ignore utm_campaign parameter",
+    "description": "Label for ignoring utm_campaign parameter"
+  },
+  "ignore_utm_medium_label": {
+    "message": "Ignore utm_medium parameter",
+    "description": "Label for ignoring utm_medium parameter"
+  },
+  "ignore_bhlid_label": {
+    "message": "Ignore _bhlid parameter",
+    "description": "Label for ignoring _bhlid parameter"
+  }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -174,5 +174,9 @@
   "ignore_bhlid_label": {
     "message": "Ignore _bhlid parameter",
     "description": "Label for ignoring _bhlid parameter"
+  },
+  "ignore_asuniq_label": {
+    "message": "Ignore asuniq parameter",
+    "description": "Label for ignoring asuniq parameter"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -158,5 +158,21 @@
   "shrunkMode": {
     "message":  "Shrunk mode:\nWhen activated, hide unpinned options.",
     "description":  "Shrunk mode\nWhen activated, hide unpinned options."
-  }  
+  },
+  "ignore_utm_source_label": {
+    "message": "Ignore utm_source parameter",
+    "description": "Label for ignoring utm_source parameter"
+  },
+  "ignore_utm_campaign_label": {
+    "message": "Ignore utm_campaign parameter",
+    "description": "Label for ignoring utm_campaign parameter"
+  },
+  "ignore_utm_medium_label": {
+    "message": "Ignore utm_medium parameter",
+    "description": "Label for ignoring utm_medium parameter"
+  },
+  "ignore_bhlid_label": {
+    "message": "Ignore _bhlid parameter",
+    "description": "Label for ignoring _bhlid parameter"
+  }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -174,5 +174,9 @@
   "ignore_bhlid_label": {
     "message": "Ignore _bhlid parameter",
     "description": "Label for ignoring _bhlid parameter"
+  },
+  "ignore_asuniq_label": {
+    "message": "Ignore asuniq parameter",
+    "description": "Label for ignoring asuniq parameter"
   }
 }

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -158,5 +158,21 @@
   "shrunkMode": {
     "message":  "Shrunk mode:\nWhen activated, hide unpinned options.",
     "description":  "Shrunk mode\nWhen activated, hide unpinned options."
-  }  
+  },
+  "ignore_utm_source_label": {
+    "message": "Ignore utm_source parameter",
+    "description": "Label for ignoring utm_source parameter"
+  },
+  "ignore_utm_campaign_label": {
+    "message": "Ignore utm_campaign parameter",
+    "description": "Label for ignoring utm_campaign parameter"
+  },
+  "ignore_utm_medium_label": {
+    "message": "Ignore utm_medium parameter",
+    "description": "Label for ignoring utm_medium parameter"
+  },
+  "ignore_bhlid_label": {
+    "message": "Ignore _bhlid parameter",
+    "description": "Label for ignoring _bhlid parameter"
+  }
 }

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -174,5 +174,9 @@
   "ignore_bhlid_label": {
     "message": "Ignore _bhlid parameter",
     "description": "Label for ignoring _bhlid parameter"
+  },
+  "ignore_asuniq_label": {
+    "message": "Ignore asuniq parameter",
+    "description": "Label for ignoring asuniq parameter"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -190,5 +190,9 @@
       "message": "Ignore _bhlid parameter",
       "description": "Label for ignoring _bhlid parameter"
     },
+    "ignore_asuniq_label": {
+      "message": "Ignore asuniq parameter",
+      "description": "Label for ignoring asuniq parameter"
+    },
     "__WET_LOCALE__": { "message": "zh-CN" }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -173,6 +173,22 @@
     "shrunkMode": {
       "message":  "Shrunk mode:\nWhen activated, hide unpinned options.",
       "description":  "Shrunk mode\nWhen activated, hide unpinned options."
-    } ,
+    },
+    "ignore_utm_source_label": {
+      "message": "Ignore utm_source parameter",
+      "description": "Label for ignoring utm_source parameter"
+    },
+    "ignore_utm_campaign_label": {
+      "message": "Ignore utm_campaign parameter",
+      "description": "Label for ignoring utm_campaign parameter"
+    },
+    "ignore_utm_medium_label": {
+      "message": "Ignore utm_medium parameter",
+      "description": "Label for ignoring utm_medium parameter"
+    },
+    "ignore_bhlid_label": {
+      "message": "Ignore _bhlid parameter",
+      "description": "Label for ignoring _bhlid parameter"
+    },
     "__WET_LOCALE__": { "message": "zh-CN" }
 }

--- a/optionPage/optionPage.html
+++ b/optionPage/optionPage.html
@@ -123,6 +123,30 @@
                   <span i18n-content="compareWithTitle"></span>
                 </label>
               </div>
+              <div class="checkboxes">
+                <label for="ignore_utm_source">
+                  <input type="checkbox" class="checkbox-filter" id="ignore_utm_source" />
+                  <span i18n-content="ignore_utm_source_label"></span>
+                </label>
+              </div>
+              <div class="checkboxes">
+                <label for="ignore_utm_campaign">
+                  <input type="checkbox" class="checkbox-filter" id="ignore_utm_campaign" />
+                  <span i18n-content="ignore_utm_campaign_label"></span>
+                </label>
+              </div>
+              <div class="checkboxes">
+                <label for="ignore_utm_medium">
+                  <input type="checkbox" class="checkbox-filter" id="ignore_utm_medium" />
+                  <span i18n-content="ignore_utm_medium_label"></span>
+                </label>
+              </div>
+              <div class="checkboxes">
+                <label for="ignore_bhlid">
+                  <input type="checkbox" class="checkbox-filter" id="ignore_bhlid" />
+                  <span i18n-content="ignore_bhlid_label"></span>
+                </label>
+              </div>
             </div>
           </li>
           <li class="list-group-item list-group-item-header d-flex justify-content-between align-items-center">

--- a/optionPage/optionPage.html
+++ b/optionPage/optionPage.html
@@ -88,6 +88,12 @@
           <li class="list-group-item">
             <div class="form-group" id="matchingRulesBody">
               <div class="checkboxes">
+                <label for="compareWithTitle">
+                  <input type="checkbox" class="checkbox-filter" id="compareWithTitle" />
+                  <span i18n-content="compareWithTitle"></span>
+                </label>
+              </div>
+              <div class="checkboxes">
                 <label for="caseInsensitive">
                   <input type="checkbox" class="checkbox-filter" id="caseInsensitive" />
                   <span i18n-content="caseInsensitive"></span>
@@ -115,12 +121,6 @@
                 <label for="ignorePathPart">
                   <input type="checkbox" class="checkbox-filter" id="ignorePathPart" />
                   <span i18n-content="ignorePathPart"></span>
-                </label>
-              </div>
-              <div class="checkboxes">
-                <label for="compareWithTitle">
-                  <input type="checkbox" class="checkbox-filter" id="compareWithTitle" />
-                  <span i18n-content="compareWithTitle"></span>
                 </label>
               </div>
               <div class="checkboxes">

--- a/optionPage/optionPage.html
+++ b/optionPage/optionPage.html
@@ -147,6 +147,12 @@
                   <span i18n-content="ignore_bhlid_label"></span>
                 </label>
               </div>
+              <div class="checkboxes">
+                <label for="ignore_asuniq">
+                  <input type="checkbox" class="checkbox-filter" id="ignore_asuniq" />
+                  <span i18n-content="ignore_asuniq_label"></span>
+                </label>
+              </div>
             </div>
           </li>
           <li class="list-group-item list-group-item-header d-flex justify-content-between align-items-center">

--- a/options.js
+++ b/options.js
@@ -90,6 +90,9 @@ const defaultOptions = {
     },
     ignore_bhlid: {
         value: true
+    },
+    ignore_asuniq: {
+        value: true
     }
 };
 
@@ -174,6 +177,7 @@ const setOptions = (storedOptions) => {
     options.ignore_utm_campaign = storedOptions.ignore_utm_campaign.value;
     options.ignore_utm_medium = storedOptions.ignore_utm_medium.value;
     options.ignore_bhlid = storedOptions.ignore_bhlid.value;
+    options.ignore_asuniq = storedOptions.ignore_asuniq.value;
 };
 
 const environment = {

--- a/options.js
+++ b/options.js
@@ -78,6 +78,18 @@ const defaultOptions = {
     },
     environment: {
         value: "firefox"
+    },
+    ignore_utm_source: {
+        value: true
+    },
+    ignore_utm_campaign: {
+        value: true
+    },
+    ignore_utm_medium: {
+        value: true
+    },
+    ignore_bhlid: {
+        value: true
     }
 };
 
@@ -158,6 +170,10 @@ const setOptions = (storedOptions) => {
     options.badgeColorDuplicateTabs = storedOptions.badgeColorDuplicateTabs.value;
     options.badgeColorNoDuplicateTabs = storedOptions.badgeColorNoDuplicateTabs.value;
     options.showBadgeIfNoDuplicateTabs = storedOptions.showBadgeIfNoDuplicateTabs.value;
+    options.ignore_utm_source = storedOptions.ignore_utm_source.value;
+    options.ignore_utm_campaign = storedOptions.ignore_utm_campaign.value;
+    options.ignore_utm_medium = storedOptions.ignore_utm_medium.value;
+    options.ignore_bhlid = storedOptions.ignore_bhlid.value;
 };
 
 const environment = {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -130,6 +130,30 @@
                                         <span i18n-content="compareWithTitle"></span>
                                     </label>
                                 </div>
+                                <div class="checkboxes">
+                                    <label for="ignore_utm_source">
+                                        <input type="checkbox" class="checkbox-filter" id="ignore_utm_source" />
+                                        <span i18n-content="ignore_utm_source_label"></span>
+                                    </label>
+                                </div>
+                                <div class="checkboxes">
+                                    <label for="ignore_utm_campaign">
+                                        <input type="checkbox" class="checkbox-filter" id="ignore_utm_campaign" />
+                                        <span i18n-content="ignore_utm_campaign_label"></span>
+                                    </label>
+                                </div>
+                                <div class="checkboxes">
+                                    <label for="ignore_utm_medium">
+                                        <input type="checkbox" class="checkbox-filter" id="ignore_utm_medium" />
+                                        <span i18n-content="ignore_utm_medium_label"></span>
+                                    </label>
+                                </div>
+                                <div class="checkboxes">
+                                    <label for="ignore_bhlid">
+                                        <input type="checkbox" class="checkbox-filter" id="ignore_bhlid" />
+                                        <span i18n-content="ignore_bhlid_label"></span>
+                                    </label>
+                                </div>
                             </div>
                         </li>
                     </div>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -95,6 +95,12 @@
                         <li class="list-group-item">
                             <div class="form-group" id="matchingRulesBody">
                                 <div class="checkboxes">
+                                    <label for="compareWithTitle">
+                                        <input type="checkbox" class="checkbox-filter" id="compareWithTitle" />
+                                        <span i18n-content="compareWithTitle"></span>
+                                    </label>
+                                </div>
+                                <div class="checkboxes">
                                     <label for="caseInsensitive">
                                         <input type="checkbox" class="checkbox-filter" id="caseInsensitive" />
                                         <span i18n-content="caseInsensitive"></span>
@@ -122,12 +128,6 @@
                                     <label for="ignorePathPart">
                                         <input type="checkbox" class="checkbox-filter" id="ignorePathPart" />
                                         <span i18n-content="ignorePathPart"></span>
-                                    </label>
-                                </div>
-                                <div class="checkboxes">
-                                    <label for="compareWithTitle">
-                                        <input type="checkbox" class="checkbox-filter" id="compareWithTitle" />
-                                        <span i18n-content="compareWithTitle"></span>
                                     </label>
                                 </div>
                                 <div class="checkboxes">

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -154,6 +154,12 @@
                                         <span i18n-content="ignore_bhlid_label"></span>
                                     </label>
                                 </div>
+                                <div class="checkboxes">
+                                    <label for="ignore_asuniq">
+                                        <input type="checkbox" class="checkbox-filter" id="ignore_asuniq" />
+                                        <span i18n-content="ignore_asuniq_label"></span>
+                                    </label>
+                                </div>
                             </div>
                         </li>
                     </div>

--- a/urlUtils.js
+++ b/urlUtils.js
@@ -23,16 +23,36 @@ const isHttps = (url) => {
 const getMatchingURL = (url) => {	
 	if (!isValidURL(url)) return url;
 	let matchingURL = url;
+	const uri = new URL(matchingURL); // Define uri here to use it multiple times
 	if (options.ignorePathPart) {
-		const uri = new URL(matchingURL);
 		matchingURL = uri.origin;
 	}
 	else if (options.ignoreSearchPart) {
-		matchingURL = matchingURL.split("?")[0];
+		matchingURL = `${uri.origin}${uri.pathname}${uri.hash}`; // Keep hash if not explicitly ignored
 	}
-	else if (options.ignoreHashPart) {
+	else { // Process search parameters if not ignoring search part
+		const searchParams = new URLSearchParams(uri.search);
+		if (options.ignore_utm_source) {
+			searchParams.delete('utm_source');
+		}
+		if (options.ignore_utm_campaign) {
+			searchParams.delete('utm_campaign');
+		}
+		if (options.ignore_utm_medium) {
+			searchParams.delete('utm_medium');
+		}
+		if (options.ignore_bhlid) {
+			searchParams.delete('_bhlid');
+		}
+		const newSearch = searchParams.toString();
+		matchingURL = `${uri.origin}${uri.pathname}${newSearch ? '?' + newSearch : ''}${uri.hash}`;
+	}
+
+	// Handle ignoreHashPart separately
+	if (options.ignoreHashPart) {
 		matchingURL = matchingURL.split("#")[0];
 	}
+
 	if (options.keepTabWithHttps) {
 		matchingURL = matchingURL.replace(/^http:\/\//i, "https://");
 	}

--- a/urlUtils.js
+++ b/urlUtils.js
@@ -44,6 +44,9 @@ const getMatchingURL = (url) => {
 		if (options.ignore_bhlid) {
 			searchParams.delete('_bhlid');
 		}
+		if (options.ignore_asuniq) {
+			searchParams.delete('asuniq');
+		}
 		const newSearch = searchParams.toString();
 		matchingURL = `${uri.origin}${uri.pathname}${newSearch ? '?' + newSearch : ''}${uri.hash}`;
 	}


### PR DESCRIPTION
Added additional "matching rules" for parameters commonly added by newsletters to their links. Different newsletters pertaining to similar topics often contain links to the same page.